### PR TITLE
do not duplicate ooo log entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-ooo",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/store.js
+++ b/store.js
@@ -1,6 +1,5 @@
 var Flume = require('flumedb')
 var OffsetLog = require('flumelog-offset')
-var mkdirp = require('mkdirp')
 var ViewHashTable = require('flumeview-hashtable')
 
 var codec = require('flumecodec/json')
@@ -26,7 +25,7 @@ module.exports = function (config) {
   )
   var store = Flume(log)
     .use('keys', ViewHashTable(2, function (key) {
-      var b = new Buffer(key.substring(1,7), 'base64').readUInt32BE(0)
+      var b = Buffer.from(key.substring(1,7), 'base64').readUInt32BE(0)
       return b
     }))
 


### PR DESCRIPTION
working on https://github.com/ssbc/ssb-ooo/issues/1

Looking for feedback on this. I am unsure if this is a good solution for this bug and it might be better to just leave this alone since the duplicates are probably not a big deal.

Brief explanation about the solution.

`oooAddQueue` is a new object that contains `ooo` messages that were fetched from the network (rather than locally) and still need to be written to the local `ooo` log. Once written to the local store, a message is removed from the queue. Subsequent calls to `ooo.get` should not add a duplicate to the local log.



